### PR TITLE
added dissconnect method

### DIFF
--- a/lib/restify-session.js
+++ b/lib/restify-session.js
@@ -468,7 +468,7 @@ module.exports = function(config) {
    *
    * @param  {Function} callback Callback to execute once connection is closed
    */
-  session.dissconnect = function (callback) {
+  session.disconnect = function (callback) {
     session.client.quit();
     session.client.on('end', callback);
   };

--- a/lib/restify-session.js
+++ b/lib/restify-session.js
@@ -1,13 +1,13 @@
 /**
  * @class node_modules.restify_session
- * 
+ *
  * @author Marcello Gesmundo
- * 
+ *
  * This module manage session for a restify server without cookies. It uses Redis (>=2.0.0) as fast session store.
  * Derived from redis-session.
- * 
+ *
  * # Example
- * 
+ *
  *      var restify = require('restify'),
  *          session = require('restify-session')({
  *              debug : true,
@@ -44,11 +44,11 @@
  *      Session-Id ViS5pHE5n8McblTATbyFUJTGJyzVFeXOcAEZ41Zs
  *
  * For more information see test/test.js into package folder.
- * 
- *  
- * 
+ *
+ *
+ *
  * # License
- * 
+ *
  * Copyright (c) 2012 Mitchell Simoens (https://github.com/mitchellsimoens/redis-session)
  *
  * Copyright (c) 2012-2014 Yoovant by Marcello Gesmundo. All rights reserved.
@@ -56,7 +56,7 @@
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
  * met:
- * 
+ *
  *    * Redistributions of source code must retain the above copyright
  *      notice, this list of conditions and the following disclaimer.
  *    * Redistributions in binary form must reproduce the above
@@ -66,7 +66,7 @@
  *    * Neither the name of Yoovant nor the names of its
  *      contributors may be used to endorse or promote products derived
  *      from this software without specific prior written permission.
- *      
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
  * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
  * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -461,6 +461,16 @@ module.exports = function(config) {
       }
       next();
     });
+  };
+
+  /**
+   * Closes the connection to the redis server
+   *
+   * @param  {Function} callback Callback to execute once connection is closed
+   */
+  session.dissconnect = function (callback) {
+    session.client.quit();
+    session.client.on('end', callback);
   };
 
   /**

--- a/test/test.js
+++ b/test/test.js
@@ -49,7 +49,7 @@ describe('Restify session manager', function(){
         done();
       });
     });
-    it('should whait for ttl and verify session data empty', function(done){
+    it('should wait for ttl and verify session data empty', function(done){
       this.timeout(session.config.ttl * 1000 + 500);
       var defer = setInterval(function() {
         session.exists(sid, function(err, exists) {
@@ -110,6 +110,16 @@ describe('Restify session manager', function(){
     });
     it('should destroy last session', function(done){
       destroySession(this, sid, done);
+    });
+  });
+  // This test needs to be last since it destroys the connection to redis
+  describe('disconnect from session', function () {
+    it('should not be connected to the redis DB anymore', function (done) {
+      session.client.connected.should.be.true;
+      session.disconnect(function () {
+        session.client.connected.should.be.false;
+        done();
+      });
     });
   });
 });


### PR DESCRIPTION
We sometimes need the ability to disconnect from the redis server. For example when running unit tests with simple libraries like tape.