### PR TITLE
chore(deps): use caret for restify and redis versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
     "test": "mocha --require should --reporter spec --recursive"
   },
   "dependencies": {
-    "redis": "0.10.x",
-    "restify": "2.7.x",
     "object_utils": "*",
+    "redis": "^0.12.1",
+    "restify": "^4.0.0",
     "secure-rnd": "*"
   },
   "analyze": false,


### PR DESCRIPTION
The current version doesn't allow for use with the latest restify and fails to install on node 0.12.x

This pr uses caret versions for restify and redis.
